### PR TITLE
fix: lint now works and added node version recommendation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -108,7 +108,8 @@
       "parser": "astro-eslint-parser",
       "parserOptions": {
         "parser": "@typescript-eslint/parser",
-        "project": "./tsconfig.json"
+        "project": "./tsconfig.json",
+        "extraFileExtensions": [".astro"]
       },
       "rules": {
         "prettier/prettier": [

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/gallium

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # Astro Boilerplate with TypeScript and Tailwind CSS [![Twitter](https://img.shields.io/twitter/url/https/twitter.com/cloudposse.svg?style=social&label=Follow%20%40Ixartz)](https://twitter.com/ixartz)
 
-🚀 Astro Boilerplate is starter code for your blog or portfolio based on Astro with Tailwind CSS 3.0. ⚡️ Made with Astro, TypeScript, ESLint, Prettier, Tailwind CSS.
+🚀 Astro Boilerplate is starter code for your blog or portfolio based on Astro
+with Tailwind CSS 3.0. ⚡️ Made with Astro, TypeScript, ESLint, Prettier,
+Tailwind CSS.
 
-Clone this project and use it to create your own Astro blog. You can check the [Astro templates demo](https://creativedesignsguru.com/demo/astro-boilerplate/).
+Clone this project and use it to create your own Astro blog. You can check the
+[Astro templates demo](https://creativedesignsguru.com/demo/astro-boilerplate/).
 
-### Features
+## Features
 
 A complete Blog feature:
 
@@ -48,11 +51,20 @@ ESLint with:
 
 - Node.js and npm
 
+#### Optional
+
+- [nvm](https://github.com/nvm-sh/nvm)
+- [volta](https://volta.sh/)
+
+While Astro-boilerplate should work with the latest Node version, it has been
+tested with the versions in .nvmrc & the bottom of package.json. At current
+writing, that's Node v16.15.1
+
 ### Getting started
 
 Run the following command on your local environment:
 
-```
+``` bash
 git clone --depth=1 https://github.com/ixartz/Astro-boilerplate
 cd my-project-name
 npm install
@@ -60,11 +72,12 @@ npm install
 
 Then, you can run locally in development mode with live reload:
 
-```
+``` bash
 npm run dev
 ```
 
-Open http://localhost:3000 with your favorite browser to see your project.
+Open [http://localhost:3000](http://localhost:3000) with your favorite browser
+to see your project.
 
 ### Deploy to production (manual)
 
@@ -74,7 +87,9 @@ You can create an optimized production build with:
 npm run build-prod
 ```
 
-Now, your blog is ready to be deployed. All generated files are located at `dist` folder, which you can deploy the folder to any hosting service you prefer.
+Now, your blog is ready to be deployed. All generated files are located at
+`dist` folder, which you can deploy the folder to any hosting service you
+prefer.
 
 ### Deploy to Netlify
 
@@ -97,7 +112,13 @@ All commands are run from the root of the project, from a terminal:
 
 ### Contributions
 
-Everyone is welcome to contribute to this project. Feel free to open an issue if you have question or found a bug.
+Everyone is welcome to contribute to this project.
+Feel free to open an issue if you have question or found a bug.
+
+### Additional Checks
+
+This README.md was linted with
+[markdownlint](https://github.com/igorshubovych/markdownlint-cli)
 
 ### License
 
@@ -105,4 +126,5 @@ Licensed under the MIT License, Copyright © 2022
 
 ---
 
-Made with ♥ by [CreativeDesignsGuru](https://creativedesignsguru.com) [![Twitter](https://img.shields.io/twitter/url/https/twitter.com/cloudposse.svg?style=social&label=Follow%20%40Ixartz)](https://twitter.com/ixartz)
+Made with ♥ by [CreativeDesignsGuru](https://creativedesignsguru.com)
+[![Twitter](https://img.shields.io/twitter/url/https/twitter.com/cloudposse.svg?style=social&label=Follow%20%40Ixartz)](https://twitter.com/ixartz)

--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
     "astro-boilerplate-components": "^1.0.8",
     "date-fns": "^2.28.0"
   },
+  "volta": {
+    "node": "16.15.1"
+  },
   "author": "Ixartz (https://github.com/ixartz)"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,5 +42,5 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.astro"]
 }


### PR DESCRIPTION
* Note that comments are not valid in json for tsconfig.json should you decide to adopt jsonlint.
* `npm run lint` now returns without error
* Recommended node version (16.15.1) will be set for nvm and/or volta users
