### PR TITLE
fix: trailing slashes and links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ pnpm-debug.log*
 # misc
 *.pem
 Thumbs.db
+.history

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,6 +9,7 @@ import { astroImageTools } from 'astro-imagetools';
 export default defineConfig({
   // base: '.', // Set a path prefix.
   site: 'https://example.com/', // Use to generate your sitemap and canonical URLs in your final build.
+  trailingSlash: 'always', // Use to always append '/' at end of url
   // Important!
   // Only official '@astrojs/*' integrations are currently supported by Astro.
   // Add 'experimental.integrations: true' to make 'astro-robots-txt' working

--- a/package-lock.json
+++ b/package-lock.json
@@ -3229,9 +3229,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001352",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001352.tgz",
-      "integrity": "sha512-GUgH8w6YergqPQDGWhJGt8GDRnY0L/iJVQcU3eJ46GYf52R8tk0Wxp0PymuFVZboJYXGiCqwozAYZNRjVj6IcA==",
+      "version": "1.0.30001497",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001497.tgz",
+      "integrity": "sha512-I4/duVK4wL6rAK/aKZl3HXB4g+lIZvaT4VLAn2rCgJ38jVLb0lv2Xug6QuqmxXFVRJMF74SPPWPJ/1Sdm3vCzw==",
       "funding": [
         {
           "type": "opencollective",
@@ -3240,6 +3240,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -14657,9 +14661,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001352",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001352.tgz",
-      "integrity": "sha512-GUgH8w6YergqPQDGWhJGt8GDRnY0L/iJVQcU3eJ46GYf52R8tk0Wxp0PymuFVZboJYXGiCqwozAYZNRjVj6IcA=="
+      "version": "1.0.30001497",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001497.tgz",
+      "integrity": "sha512-I4/duVK4wL6rAK/aKZl3HXB4g+lIZvaT4VLAn2rCgJ38jVLb0lv2Xug6QuqmxXFVRJMF74SPPWPJ/1Sdm3vCzw=="
     },
     "ccount": {
       "version": "2.0.1",

--- a/src/pages/posts/fifth-post.md
+++ b/src/pages/posts/fifth-post.md
@@ -7,4 +7,4 @@ imgSrc: '/assets/images/image-post2.jpeg'
 imgAlt: 'Image post 2'
 ---
 
-Full typography example at [this page](./sixth-post).
+Full typography example at [this page](../sixth-post/).

--- a/src/pages/posts/first-post.md
+++ b/src/pages/posts/first-post.md
@@ -7,4 +7,4 @@ imgSrc: '/assets/images/image-post7.jpeg'
 imgAlt: 'Image post 7'
 ---
 
-Full typography example at [this page](./sixth-post).
+Full typography example at [this page](../sixth-post/).

--- a/src/pages/posts/forth-post.md
+++ b/src/pages/posts/forth-post.md
@@ -7,4 +7,4 @@ imgSrc: '/assets/images/image-post3.jpeg'
 imgAlt: 'Image post 3'
 ---
 
-Full typography example at [this page](./sixth-post).
+Full typography example at [this page](../sixth-post/).

--- a/src/pages/posts/hello-world.md
+++ b/src/pages/posts/hello-world.md
@@ -7,4 +7,4 @@ imgSrc: '/assets/images/image-post6.jpeg'
 imgAlt: 'Image post 6'
 ---
 
-Full typography example at [this page](./sixth-post).
+Full typography example at [this page](../sixth-post/).

--- a/src/pages/posts/second-post.md
+++ b/src/pages/posts/second-post.md
@@ -7,4 +7,4 @@ imgSrc: '/assets/images/image-post5.jpeg'
 imgAlt: 'Image post 5'
 ---
 
-Full typography example at [this page](./sixth-post).
+Full typography example at [this page](../sixth-post/).

--- a/src/pages/posts/sixth-post.md
+++ b/src/pages/posts/sixth-post.md
@@ -118,7 +118,7 @@ Some text to show that the reference links can follow later.
 Images included in _\_posts_ folder are lazy loaded.
 
 Inline-style:
-![alt text](/src/images/random.jpeg 'Logo Title Text 1')
+![alt text](http://localhost:3000/src/images/random.jpeg 'Logo Title Text 1')
 
 ## Table
 

--- a/src/pages/posts/sixth-post.md
+++ b/src/pages/posts/sixth-post.md
@@ -118,7 +118,7 @@ Some text to show that the reference links can follow later.
 Images included in _\_posts_ folder are lazy loaded.
 
 Inline-style:
-![alt text](http://localhost:3000/src/images/random.jpeg 'Logo Title Text 1')
+![alt text](/src/images/random.jpeg 'Logo Title Text 1')
 
 ## Table
 

--- a/src/pages/posts/third-post.md
+++ b/src/pages/posts/third-post.md
@@ -7,4 +7,4 @@ imgSrc: '/assets/images/image-post4.jpeg'
 imgAlt: 'Image post 4'
 ---
 
-Full typography example at [this page](./sixth-post).
+Full typography example at [this page](../sixth-post/).

--- a/src/partials/Navbar.tsx
+++ b/src/partials/Navbar.tsx
@@ -33,7 +33,7 @@ const Navbar = () => (
       </a>
 
       <NavMenu>
-        <NavMenuItem href="/posts">Blogs</NavMenuItem>
+        <NavMenuItem href="/posts/">Blogs</NavMenuItem>
         <NavMenuItem href="/">GitHub</NavMenuItem>
         <NavMenuItem href="/">Twitter</NavMenuItem>
       </NavMenu>


### PR DESCRIPTION
Navbar /post --> /post/
Added .history (vscode extension) folder ignored
Fix broken link to /postX/sixth-post
Fix Broken sisth-post
Npm Caniuse-lite update (browserlist)

Requested by: zzikkzzakk